### PR TITLE
Fixed eta-cabal dependency issue breaking the build.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -12210,9 +12210,9 @@ inherit (pkgs) mesa;};
          }) {};
       "etlas" = callPackage
         ({ mkDerivation, array, async, base, base16-bytestring, binary
-         , bytestring, Cabal, containers, cryptohash-sha256, deepseq
+         , bytestring, Cabal, containers, cryptohash-sha256, deepseq, dhall
          , directory, echo, edit-distance, etlas-cabal, filepath
-         , hackage-security, hashable, HTTP, mtl, network, network-uri
+         , hackage-security, hashable, HTTP, microlens, mtl, network, network-uri
          , pretty, process, random, stdenv, stm, tar, time, unix, zlib
          }:
          mkDerivation {
@@ -12224,8 +12224,8 @@ inherit (pkgs) mesa;};
            setupHaskellDepends = [ base Cabal filepath process ];
            libraryHaskellDepends = [
              array async base base16-bytestring binary bytestring containers
-             cryptohash-sha256 deepseq directory echo edit-distance etlas-cabal
-             filepath hackage-security hashable HTTP mtl network network-uri
+             cryptohash-sha256 deepseq directory dhall echo edit-distance etlas-cabal
+             filepath hackage-security hashable HTTP microlens mtl network network-uri
              pretty process random stm tar time unix zlib
            ];
            executableHaskellDepends = [ base directory etlas-cabal filepath ];

--- a/default.nix
+++ b/default.nix
@@ -12237,7 +12237,7 @@ inherit (pkgs) mesa;};
          }) {};
       "etlas-cabal" = callPackage
         ({ mkDerivation, array, base, binary, bytestring, containers
-         , deepseq, directory, filepath, pretty, process, stdenv, time, unix
+         , deepseq, directory, filepath, parsec, pretty, process, stdenv, time, unix
          }:
          mkDerivation {
            pname = "etlas-cabal";
@@ -12245,7 +12245,7 @@ inherit (pkgs) mesa;};
            src = ./etlas/etlas-cabal;
            libraryHaskellDepends = [
              array base binary bytestring containers deepseq directory filepath
-             pretty process time unix
+             parsec pretty process time unix
            ];
            doHaddock = false;
            doCheck = false;


### PR DESCRIPTION
Refs https://github.com/typelead/eta/issues/874

Fixes the error below. Once merged I'm guessing a followup PR is needed to update the `eta-nix` tarball in https://github.com/typelead/eta/blob/master/default.nix with a new one.

```Configuring etlas-cabal-1.6.0.0...
CallStack (from HasCallStack):
  die', called at libraries/Cabal/Cabal/Distribution/Simple/Configure.hs:948:20 in Cabal-2.0.1.0:Distribution.Simple.Configure
  configureFinalizedPackage, called at libraries/Cabal/Cabal/Distribution/Simple/Configure.hs:470:12 in Cabal-2.0.1.0:Distribution.Simple.Configure
  configure, called at libraries/Cabal/Cabal/Distribution/Simple.hs:570:20 in Cabal-2.0.1.0:Distribution.Simple
  confHook, called at libraries/Cabal/Cabal/Distribution/Simple/UserHooks.hs:67:5 in Cabal-2.0.1.0:Distribution.Simple.UserHooks
  configureAction, called at libraries/Cabal/Cabal/Distribution/Simple.hs:174:19 in Cabal-2.0.1.0:Distribution.Simple
  defaultMainHelper, called at libraries/Cabal/Cabal/Distribution/Simple.hs:119:27 in Cabal-2.0.1.0:Distribution.Simple
  defaultMain, called at Setup.hs:3:8 in main:Main
Setup: Encountered missing dependencies:
parsec >=3.1.13.0 && <3.2
builder for '/nix/store/x2b1i9wn0y46cy12m65hw98b8alwq0j4-etlas-cabal-1.4.0.2.drv' failed with exit code 1
cannot build derivation '/nix/store/hr0hsdznw823fy1jl04d9xcggnlfqssh-eta-build-0.0.0.drv': 1 dependencies couldn't be built
error: build of '/nix/store/74lgij6slxj2bm4n7jlqn34wklx8rcw2-eta-pkg-0.8.0.3.drv', '/nix/store/hr0hsdznw823fy1jl04d9xcggnlfqssh-eta-build-0.0.0.drv', '/nix/store/hs5v4317zfr95ixwap0qs6j8cgsimnw0-eta-0.8.0.3.drv', '/nix/store/hxphzj1g86iv88s25nll714nxamm1qli-etlas-1.4.0.2.drv' failed
```
